### PR TITLE
Fix the path of chess.info to make it working with el-get.

### DIFF
--- a/doc/chess.texi
+++ b/doc/chess.texi
@@ -1,6 +1,6 @@
 \input texinfo  @c -*-texinfo-*-
 
-@setfilename ../chess.info
+@setfilename chess.info
 @documentencoding UTF-8
 @documentlanguage en
 @settitle Emacs Chess: chess.el


### PR DESCRIPTION
Hi!
This slight fix repairs the installation of emacs-chess by means of el-get.

Best regards,
Vladimir.
