### PR TITLE
Fix typo in option docstring

### DIFF
--- a/chess-crafty.el
+++ b/chess-crafty.el
@@ -26,7 +26,7 @@
 (require 'chess-var)
 
 (defgroup chess-crafty nil
-  "The publically available chess engine 'crafty'."
+  "The publicly available chess engine 'crafty'."
   :group 'chess-engine)
 
 (defcustom chess-crafty-path (or (executable-find "crafty")

--- a/chess-fruit.el
+++ b/chess-fruit.el
@@ -23,7 +23,7 @@
 (require 'chess-uci)
 
 (defgroup chess-fruit nil
-  "The publically available chess engine 'fruit'."
+  "The publicly available chess engine 'fruit'."
   :group 'chess-engine
   :link '(url-link "http://www.fruitchess.com/"))
 

--- a/chess-glaurung.el
+++ b/chess-glaurung.el
@@ -23,7 +23,7 @@
 (require 'chess-uci)
 
 (defgroup chess-glaurung nil
-  "The publically available chess engine 'glaurung'."
+  "The publicly available chess engine 'glaurung'."
   :group 'chess-engine
   :link '(url-link "http://www.glaurungchess.com/"))
 

--- a/chess-gnuchess.el
+++ b/chess-gnuchess.el
@@ -25,7 +25,7 @@
 (require 'chess-fen)
 
 (defgroup chess-gnuchess nil
-  "The publically available chess engine 'gnuchess'."
+  "The publicly available chess engine 'gnuchess'."
   :group 'chess-engine)
 
 (defcustom chess-gnuchess-path (let ((exec-path (cons "/usr/games" exec-path)))

--- a/chess-phalanx.el
+++ b/chess-phalanx.el
@@ -24,7 +24,7 @@
 (require 'chess-common)
 
 (defgroup chess-phalanx nil
-  "The publically available chess engine 'phalanx'."
+  "The publicly available chess engine 'phalanx'."
   :group 'chess-engine
   :link '(url-link "http://phalanx.sourceforge.net/"))
 

--- a/chess-sjeng.el
+++ b/chess-sjeng.el
@@ -24,7 +24,7 @@
 (require 'chess-fen)
 
 (defgroup chess-sjeng nil
-  "The publically available chess engine 'sjeng'."
+  "The publicly available chess engine 'sjeng'."
   :group 'chess-engine
   :link '(url-link "http://sjeng.sourceforge.net"))
 

--- a/chess-stockfish.el
+++ b/chess-stockfish.el
@@ -23,7 +23,7 @@
 (require 'chess-uci)
 
 (defgroup chess-stockfish nil
-  "The publically available chess engine 'stockfish'."
+  "The publicly available chess engine 'stockfish'."
   :group 'chess-engine
   :link '(url-link "http://www.stockfishchess.com"))
 


### PR DESCRIPTION
* chess-crafty.el (chess-crafty):
* chess-fruit.el (chess-fruit):
* chess-glaurung.el (chess-glaurung):
* chess-gnuchess.el (chess-gnuchess):
* chess-phalanx.el (chess-phalanx):
* chess-sjeng.el (chess-sjeng):
* chess-stockfish.el (chess-stockfish): Fix typo.