### PR TITLE
Stockfish syntax

### DIFF
--- a/chess-algebraic.el
+++ b/chess-algebraic.el
@@ -142,7 +142,7 @@ This regexp handles both long and short form.")
 			     (list which target))))
 		     (chess-error 'no-candidates move))))))
 	    (when promotion
-	      (nconc changes (list :promote (aref promotion 0))))))
+	      (nconc changes (list :promote (aref (upcase promotion) 0))))))
 
 	(when changes
 	  (if (and trust mate)

--- a/chess-algebraic.el
+++ b/chess-algebraic.el
@@ -59,13 +59,19 @@
 (require 'chess-pos)
 
 (defconst chess-algebraic-regexp
-  (rx (group (or (or "O-O" "O-O-O")
-		 (and (optional (group (char ?N ?B ?R ?Q ?K)))
+  (rx (group (or (or "O-O" "O-O-O" "0-0" "0-0-0")
+		 (and (optional (group (char ?N ?B ?R ?Q ?K
+					     ?♔ ?♕ ?♖ ?♗ ?♘
+					     ?♚ ?♛ ?♜ ?♝ ?♞)))
 		      (optional (char ?/))
 		      (group (optional (char "a-h")) (optional (char "1-8")))
 		      (optional (group (char ?- ?x)))
 		      (group (char "a-h") (char "1-8"))
-		      (optional (group ?= (group (char ?N ?B ?R ?Q ?K)))))))
+		      (optional (group (optional (char ?=))
+                                       (group (char ?N ?B ?R ?Q ?K
+                                                    ?n ?b ?r ?q ?k
+                                                    ?♔ ?♕ ?♖ ?♗ ?♘
+                                                    ?♚ ?♛ ?♜ ?♝ ?♞)))))))
       (optional (group (char ?+ ?#))))
   "A regular expression that matches all possible algebraic moves.
 This regexp handles both long and short form.")


### PR DESCRIPTION
Hi!
What do you think of this? I want to support syntax such as "c7c8q", i.e when moving a pawn from c7 to c8 promoting to queen. This is output from my chess engine (Stockfish).

I changed the regex so that "=" is optional when promoting. I also added the lower case piece characters as valid promotion pieces (and I made sure to upcase the promotion char on line 139 even though it might not be necessary?)

I am a little confused because in my version from ELPA (2.0.4) the regex also accepted the unicode "figurine" piece characters (hence why they are present in my commits) but they are obviously not there in the github repo. Is the github repo up to date? Or were they removed?