### PR TITLE
avoid ask-promotion returning nil

### DIFF
--- a/chess-game.el
+++ b/chess-game.el
@@ -223,7 +223,7 @@ if INDEX is nil)."
 
 (defun chess-game-ply (game &optional index)
   "Return a ply of GAME.
-If INDEX is non-nil, the last played ply is returned."
+If INDEX is nil, the last played ply is returned."
   (cl-assert game)
   (if index
       (nth index (chess-game-plies game))

--- a/chess-ics.el
+++ b/chess-ics.el
@@ -470,6 +470,7 @@ See `chess-ics-game'.")
        (chess-game-set-data game 'ics-game-number game-number)
        (chess-game-set-data game 'ics-buffer (current-buffer))
        (chess-game-set-tag game "Site" chess-ics-server)
+       (chess-engine-set-response-handler (current-buffer))
        (while tags
 	 (cl-assert (keywordp (car tags)))
 	 (chess-game-set-tag

--- a/chess-ply.el
+++ b/chess-ply.el
@@ -176,22 +176,21 @@
   (cl-assert (vectorp position))
   (list position))
 
-
 (defconst promotion-options
-  '((queen  ?Q ?q)
-    (rook   ?R ?r)
-    (bishop ?B ?b)
-    (knight ?N ?n)))
+  '((?q ?Q "[q]ueen")
+    (?r ?R "(r)ook")
+    (?b ?B "(b)ishop")
+    (?n ?N "k(n)ight")))
 
 (defun ask-promotion (white)
-  (nth (if white 1 2)
-       (assoc (intern-soft
-               (or (completing-read
-                    "Symbol? "
-                    (mapcar (lambda (x) (symbol-name (car x)))
-                            promotion-options))
-                   "queen"))
-              promotion-options)))
+  (let ((prompts (mapcar (lambda (x) (nth 2 x)) promotion-options))
+        (choices (append '(?\n ?\r) (mapcar (lambda (x) (car x)) promotion-options))))
+    (nth (if white 1 0)
+         (or 
+          (assoc
+           (read-char-choice (concat "Promote to: " (mapconcat 'identity prompts " ") " ? ")
+                             choices t) promotion-options)
+          (car promotion-options)))))
 
 (defun chess-ply-create (position &optional valid-p &rest changes)
   "Create a ply from the given POSITION by applying the supplied CHANGES.


### PR DESCRIPTION
`ask-promotion` currently returns nil if the user enters anything other than "queen", "rook", "bishop", or "knight" (despite the or'ing with the "queen" string literal).

Please consider the less ambiguous "read-char-choice" instead of "completing-read" for specifying the promotion.