### PR TITLE
assign default chess-engine handler for chess-ics

### DIFF
--- a/chess-ics.el
+++ b/chess-ics.el
@@ -470,6 +470,7 @@ See `chess-ics-game'.")
        (chess-game-set-data game 'ics-game-number game-number)
        (chess-game-set-data game 'ics-buffer (current-buffer))
        (chess-game-set-tag game "Site" chess-ics-server)
+       (chess-engine-set-response-handler (current-buffer))
        (while tags
 	 (cl-assert (keywordp (car tags)))
 	 (chess-game-set-tag


### PR DESCRIPTION
When clocks run out playing over the internet, the following error occurs.
```
error in process filter: Symbol’s function definition is void: nil [2 times]
```
The undefined function is `chess-engine-response-handler` which is never assigned under `chess-ics` (but is under `chess-engine`).

https://github.com/jwiegley/emacs-chess/blob/master/chess-ics.el#L403