### PR TITLE
Fix submodule links by switching from "git://" to "https://"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "pieces"]
 	path = pieces
-	url = git://github.com/jwiegley/emacs-chess.git
+	url = https://github.com/jwiegley/emacs-chess.git
 [submodule "sounds"]
 	path = sounds
-	url = git://github.com/jwiegley/emacs-chess.git
+	url = https://github.com/jwiegley/emacs-chess.git


### PR DESCRIPTION
[As a result of Github's security concerns](https://github.blog/security/application-security/improving-git-protocol-security-github/), "git://" won't allow for the intended updating of the the submodules and so "https" must be used instead.